### PR TITLE
Add control buttons with Discord UI

### DIFF
--- a/discord_music_bot/commands/__init__.py
+++ b/discord_music_bot/commands/__init__.py
@@ -2,9 +2,11 @@ from ..client import CustomClient
 from .audio import add_audio_commands
 from .queue import add_queue_commands
 from .streaming import add_streaming_commands
+from .controls import add_control_commands
 
 
 def add_commands(client: CustomClient) -> None:
     add_audio_commands(client)
     add_queue_commands(client)
     add_streaming_commands(client)
+    add_control_commands(client)

--- a/discord_music_bot/commands/controls.py
+++ b/discord_music_bot/commands/controls.py
@@ -1,0 +1,20 @@
+# mypy: disable-error-code=arg-type
+import discord
+from discord import app_commands
+
+from ..client import CustomClient
+from ..helpers import get_current_player
+from ..views import ControlView
+
+
+def add_control_commands(client: CustomClient) -> None:
+    @client.tree.command(
+        name="controls",
+        description="show playback control buttons",
+    )
+    async def show_controls(interaction: discord.Interaction) -> None:
+        await get_current_player(interaction)
+        view = ControlView()
+        await interaction.response.send_message(
+            "Player controls:", view=view, ephemeral=True
+        )

--- a/discord_music_bot/commands/controls.py
+++ b/discord_music_bot/commands/controls.py
@@ -1,6 +1,5 @@
 # mypy: disable-error-code=arg-type
 import discord
-from discord import app_commands
 
 from ..client import CustomClient
 from ..helpers import get_current_player

--- a/discord_music_bot/views.py
+++ b/discord_music_bot/views.py
@@ -1,0 +1,72 @@
+import discord
+import wavelink
+
+from typing import cast
+
+from .helpers import get_current_player
+from .client import CustomClient
+
+
+class ControlView(discord.ui.View):
+    def __init__(self) -> None:
+        super().__init__(timeout=None)
+
+    @discord.ui.button(
+        label="Pause/Resume",
+        style=discord.ButtonStyle.primary,
+        custom_id="control_pause",
+    )
+    async def pause(
+        self, interaction: discord.Interaction, _button: discord.ui.Button
+    ) -> None:
+        player = await get_current_player(interaction)
+
+        if not player.playing:
+            await interaction.response.send_message(
+                "Not playing", ephemeral=True
+            )
+            return
+
+        await player.pause(not player.paused)
+        await interaction.response.send_message(
+            "Paused" if player.paused else "Resumed", ephemeral=True
+        )
+
+    @discord.ui.button(
+        label="Skip",
+        style=discord.ButtonStyle.secondary,
+        custom_id="control_skip",
+    )
+    async def skip(
+        self, interaction: discord.Interaction, _button: discord.ui.Button
+    ) -> None:
+        player = await get_current_player(interaction)
+        skipped = await player.skip()
+
+        if not skipped:
+            await interaction.response.send_message(
+                "Nothing to skip", ephemeral=True
+            )
+            return
+
+        await interaction.response.send_message(
+            f"Skipping **`{skipped.title} - {skipped.author}`**",
+            ephemeral=True,
+        )
+        if not player.playing:
+            await interaction.followup.send("Finished playing queue")
+
+    @discord.ui.button(
+        label="Disconnect",
+        style=discord.ButtonStyle.danger,
+        custom_id="control_disconnect",
+    )
+    async def leave(
+        self, interaction: discord.Interaction, _button: discord.ui.Button
+    ) -> None:
+        player = await get_current_player(interaction)
+
+        await player.disconnect()
+        await interaction.response.send_message("Ok", ephemeral=True)
+        client = cast(CustomClient, interaction.client)
+        await client.change_presence(status=discord.Status.idle)

--- a/discord_music_bot/views.py
+++ b/discord_music_bot/views.py
@@ -1,9 +1,10 @@
 import discord
 import wavelink
+from datetime import timedelta
 
 from typing import cast
 
-from .helpers import get_current_player
+from .helpers import format_timedelta, get_current_player
 from .client import CustomClient
 
 
@@ -12,9 +13,35 @@ class ControlView(discord.ui.View):
         super().__init__(timeout=None)
 
     @discord.ui.button(
+        label="10s Back",
+        style=discord.ButtonStyle.secondary,
+        custom_id="control_back_10",
+        row=0,
+    )
+    async def back_ten(
+        self, interaction: discord.Interaction, _button: discord.ui.Button
+    ) -> None:
+        player = await get_current_player(interaction)
+
+        if not player.current:
+            await interaction.response.send_message(
+                "Not playing anything", ephemeral=True
+            )
+            return
+
+        new_position = max(player.position - 10_000, 0)
+        await player.seek(new_position)
+        await interaction.response.send_message(
+            "Seeking to "
+            f"{format_timedelta(timedelta(milliseconds=new_position))}",
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
         label="Pause/Resume",
         style=discord.ButtonStyle.primary,
         custom_id="control_pause",
+        row=0,
     )
     async def pause(
         self, interaction: discord.Interaction, _button: discord.ui.Button
@@ -33,9 +60,39 @@ class ControlView(discord.ui.View):
         )
 
     @discord.ui.button(
+        label="10s Forward",
+        style=discord.ButtonStyle.secondary,
+        custom_id="control_forward_10",
+        row=0,
+    )
+    async def forward_ten(
+        self, interaction: discord.Interaction, _button: discord.ui.Button
+    ) -> None:
+        player = await get_current_player(interaction)
+
+        if not player.current:
+            await interaction.response.send_message(
+                "Not playing anything", ephemeral=True
+            )
+            return
+
+        track = player.current
+        new_position = min(
+            player.position + 10_000,
+            track.length,
+        )
+        await player.seek(new_position)
+        await interaction.response.send_message(
+            "Seeking to "
+            f"{format_timedelta(timedelta(milliseconds=new_position))}",
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
         label="Skip",
         style=discord.ButtonStyle.secondary,
         custom_id="control_skip",
+        row=1,
     )
     async def skip(
         self, interaction: discord.Interaction, _button: discord.ui.Button
@@ -57,9 +114,31 @@ class ControlView(discord.ui.View):
             await interaction.followup.send("Finished playing queue")
 
     @discord.ui.button(
-        label="Disconnect",
+        label="Loop",
+        style=discord.ButtonStyle.secondary,
+        custom_id="control_loop",
+        row=1,
+    )
+    async def loop(
+        self, interaction: discord.Interaction, _button: discord.ui.Button
+    ) -> None:
+        player = await get_current_player(interaction)
+        is_looped = player.queue.mode == wavelink.QueueMode.normal
+
+        player.queue.mode = (
+            wavelink.QueueMode.loop if is_looped else wavelink.QueueMode.normal
+        )
+
+        await interaction.response.send_message(
+            f"Current track is {'' if is_looped else 'un'}looped",
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="Shut the fuck up",
         style=discord.ButtonStyle.danger,
         custom_id="control_disconnect",
+        row=1,
     )
     async def leave(
         self, interaction: discord.Interaction, _button: discord.ui.Button


### PR DESCRIPTION
## Summary
- create `ControlView` with pause/resume, skip and disconnect buttons
- expose `/controls` command to show the new control panel
- register the new command when initializing commands

## Testing
- `poetry run pre-commit run -a`


------
https://chatgpt.com/codex/tasks/task_e_683ff0989a98832eb46f8b3ae7b6ceb2