### PR TITLE
Refactor bot commands into reusable service helpers

### DIFF
--- a/discord_music_bot/commands/audio.py
+++ b/discord_music_bot/commands/audio.py
@@ -1,40 +1,37 @@
 # mypy: disable-error-code=arg-type
 
-import re
-from datetime import timedelta
-
 import discord
-import wavelink
 from discord import app_commands
-from wavelink.types.filters import Equalizer
 
 from ..client import CustomClient
-from ..helpers import format_timedelta, get_current_player
+from ..helpers import get_current_player
+from ..player_service import (
+    apply_equalizer_settings,
+    disconnect_player,
+    parse_equalizer,
+    parse_timestamp,
+    reset_player_filters,
+    seek_player,
+    set_playback_speed,
+    set_player_volume,
+    toggle_pause,
+)
 
 
 def add_audio_commands(client: CustomClient) -> None:
     @client.tree.command(name="pause", description="pause/resume current song")
     async def pause(interaction: discord.Interaction) -> None:
         player = await get_current_player(interaction)
-
-        if not player.playing:
-            await interaction.response.send_message("Not playing")
-            return
-
-        await player.pause(not player.paused)
-        await interaction.response.send_message(
-            "Paused" if player.paused else "Resumed"
-        )
+        message = await toggle_pause(player)
+        await interaction.response.send_message(message)
 
     @client.tree.command(
         name="shut_the_fuck_up", description="SHUT THE FUCK UP"
     )
     async def leave(interaction: discord.Interaction) -> None:
         player = await get_current_player(interaction)
-
-        await player.disconnect()
-        await interaction.response.send_message("Ok")
-        await client.change_presence(status=discord.Status.idle)
+        message = await disconnect_player(player, client)
+        await interaction.response.send_message(message)
 
     @client.tree.command(name="volume", description="set audio volume")
     @app_commands.describe(volume="percentage from 0 to 1000")
@@ -43,16 +40,14 @@ def add_audio_commands(client: CustomClient) -> None:
         *,
         volume: app_commands.Range[int, 0, 1000],
     ) -> None:
-        player = await get_current_player(interaction)
-
         if not 0 <= volume <= 1000:
             await interaction.response.send_message(
                 "Volume must be in range 0-1000"
             )
             return
-
-        await player.set_volume(volume)
-        await interaction.response.send_message(f"Volume set to {volume}%")
+        player = await get_current_player(interaction)
+        message = await set_player_volume(player, volume)
+        await interaction.response.send_message(message)
 
     @client.tree.command(
         name="seek", description="seek to a specified position"
@@ -60,39 +55,13 @@ def add_audio_commands(client: CustomClient) -> None:
     @app_commands.describe(position="timestamp (4:20) or seconds (260)")
     async def seek(interaction: discord.Interaction, *, position: str) -> None:
         player = await get_current_player(interaction)
-
-        if not player.current:
-            await interaction.response.send_message(
-                "Not playing anything right now"
-            )
-            return
-
-        # matches \d+:\d+:\d+, \d+:\d+ and \d+
-        # this allows entering position as a number of seconds.
-        # for example, 300 will be treated as 5 minutes.
-        matches = re.match(r"^(?:(?:(\d+):)?(\d+):)?(\d+)$", position)
-
-        if not matches:
+        position_td = parse_timestamp(position)
+        if not position_td:
             await interaction.response.send_message("Invalid position format")
             return
 
-        hours, minutes, seconds = (
-            int(m) if m else 0 for m in matches.groups()
-        )
-        position_td = timedelta(hours=hours, minutes=minutes, seconds=seconds)
-
-        duration = timedelta(seconds=player.current.length)
-        if duration < position_td:
-            await interaction.response.send_message(
-                "Track's total length is "
-                f"{format_timedelta(duration)}, that is too far"
-            )
-            return
-
-        await player.seek(position_td.seconds * 1000)
-        await interaction.response.send_message(
-            f"Seeking to {format_timedelta(position_td)}"
-        )
+        message = await seek_player(player, position_td)
+        await interaction.response.send_message(message)
 
     @client.tree.command(
         name="equalizer",
@@ -109,29 +78,9 @@ def add_audio_commands(client: CustomClient) -> None:
     ) -> None:
         player = await get_current_player(interaction)
 
-        # bands is list of tuples that contain band number and its gain,
-        # where band is a frequency and gain is its amplification factor.
-        # the lower the band number, the lower the frequency
-
-        # for example: [(1, 0.75), (2, 0.8), (3, 0.5)]
-        # in this example, three low frequency bands are amplified
-        bands: list[Equalizer] = []
-        for param in settings.strip().split(" "):
-            if not param:
-                continue
-
-            band, gain = param.split(":")
-            bands.append(Equalizer(band=int(band), gain=float(gain)))
-        filters: wavelink.Filters = player.filters
-        filters.equalizer.set(bands=bands)
-
-        try:
-            await player.set_filters(filters, seek=True)
-        except ValueError:
-            await interaction.response.send_message("Invalid value")
-            return
-
-        await interaction.response.send_message("Equalizer added")
+        bands = parse_equalizer(settings)
+        message = await apply_equalizer_settings(player, bands)
+        await interaction.response.send_message(message)
 
     @client.tree.command(name="speed", description="set playback speed")
     @app_commands.describe(
@@ -144,12 +93,8 @@ def add_audio_commands(client: CustomClient) -> None:
         pitch: app_commands.Range[float, 0.0] = 1.0,
     ) -> None:
         player = await get_current_player(interaction)
-
-        filters: wavelink.Filters = player.filters
-        filters.timescale.set(speed=speed, pitch=pitch)
-
-        await player.set_filters(filters, seek=True)
-        await interaction.response.send_message("New speed applied")
+        message = await set_playback_speed(player, speed, pitch)
+        await interaction.response.send_message(message)
 
     @client.tree.command(
         name="reset_filters",
@@ -157,9 +102,5 @@ def add_audio_commands(client: CustomClient) -> None:
     )
     async def reset_filters(interaction: discord.Interaction) -> None:
         player = await get_current_player(interaction)
-
-        filters: wavelink.Filters = player.filters
-        filters.reset()
-
-        await player.set_filters(filters, seek=True)
-        await interaction.response.send_message("Filters reset")
+        message = await reset_player_filters(player)
+        await interaction.response.send_message(message)

--- a/discord_music_bot/commands/queue.py
+++ b/discord_music_bot/commands/queue.py
@@ -1,12 +1,17 @@
 # mypy: disable-error-code=arg-type
 
-from datetime import timedelta
-
 import discord
-from wavelink import QueueMode, AutoPlayMode
 
 from ..client import CustomClient
-from ..helpers import format_timedelta, get_current_player
+from ..helpers import get_current_player
+from ..player_service import (
+    clear_queue as clear_player_queue,
+    now_playing_embed,
+    queue_embed,
+    skip_current,
+    toggle_autoplay as toggle_autoplay_mode,
+    toggle_loop,
+)
 
 
 def add_queue_commands(client: CustomClient) -> None:
@@ -24,28 +29,7 @@ def add_queue_commands(client: CustomClient) -> None:
             )
             return
 
-        embed = discord.Embed(
-            title=track.title, colour=discord.Colour.random()
-        )
-
-        if track.author:
-            embed.add_field(name="Author", value=track.author)
-
-        position = timedelta(seconds=player.position // 1000)
-        embed.add_field(name="Position", value=format_timedelta(position))
-
-        duration = timedelta(seconds=track.length // 1000)
-        embed.add_field(name="Duration", value=format_timedelta(duration))
-
-        if track.uri:
-            embed.add_field(name="Link", value=track.uri)
-
-        if track.artwork:
-            embed.set_image(url=track.artwork)
-
-        if track.album.name:
-            embed.add_field(name="Album", value=track.album.name)
-
+        embed = now_playing_embed(player)
         await interaction.response.send_message(embed=embed)
 
     @client.tree.command(
@@ -58,15 +42,7 @@ def add_queue_commands(client: CustomClient) -> None:
             await interaction.response.send_message("Queue is empty")
             return
 
-        embed = discord.Embed(
-            title="Songs in queue:", colour=discord.Colour.random()
-        )
-
-        for i, track in enumerate(player.queue, start=1):
-            embed.add_field(
-                name=f"`{track.title} - {track.author}`", value=str(i)
-            )
-
+        embed = queue_embed(list(player.queue), "Songs in queue:")
         await interaction.response.send_message(embed=embed)
 
     @client.tree.command(
@@ -80,61 +56,33 @@ def add_queue_commands(client: CustomClient) -> None:
             await interaction.response.send_message("Autoplay queue is empty")
             return
 
-        embed = discord.Embed(
-            title="Songs in autoplay queue:", colour=discord.Colour.random()
-        )
-
-        for i, track in enumerate(player.auto_queue, start=1):
-            embed.add_field(
-                name=f"`{track.title} - {track.author}`", value=str(i)
-            )
-
+        embed = queue_embed(list(player.auto_queue), "Songs in autoplay queue:")
         await interaction.response.send_message(embed=embed)
 
     @client.tree.command(name="clear", description="clear the queue")
     async def clear_queue(interaction: discord.Interaction) -> None:
         player = await get_current_player(interaction)
-
-        player.queue.clear()
-        await interaction.response.send_message("Queue cleared")
+        message = await clear_player_queue(player)
+        await interaction.response.send_message(message)
 
     @client.tree.command(
         name="skip", description="skip currently playing song"
     )
     async def play_next(interaction: discord.Interaction) -> None:
         player = await get_current_player(interaction)
-        skipped_item = await player.skip()
-
-        if not skipped_item:
-            await interaction.response.send_message("Nothing to skip")
-            return
-
-        await interaction.response.send_message(
-            f"Skipping **`{skipped_item.title} - {skipped_item.author}`**"
-        )
+        message = await skip_current(player)
+        await interaction.response.send_message(message)
         if not player.playing:
             await interaction.followup.send("Finished playing queue")
 
     @client.tree.command(name="loop", description="loop current track")
     async def loop_track(interaction: discord.Interaction) -> None:
         player = await get_current_player(interaction)
-        is_looped = player.queue.mode == QueueMode.normal
-
-        player.queue.mode = QueueMode.loop if is_looped else QueueMode.normal
-
-        await interaction.response.send_message(
-            f"Current track is {'' if is_looped else 'un'}looped"
-        )
+        message = toggle_loop(player)
+        await interaction.response.send_message(message)
 
     @client.tree.command(name="autoplay", description="toggle autoplay")
     async def toggle_autoplay(interaction: discord.Interaction) -> None:
         player = await get_current_player(interaction)
-
-        player.autoplay = (
-            AutoPlayMode.enabled
-            if player.autoplay == AutoPlayMode.disabled
-            else AutoPlayMode.disabled
-        )
-
-        state = "" if player.autoplay != AutoPlayMode.disabled else "not "
-        await interaction.response.send_message(f"Autoplay is {state}enabled")
+        message = toggle_autoplay_mode(player)
+        await interaction.response.send_message(message)

--- a/discord_music_bot/commands/streaming.py
+++ b/discord_music_bot/commands/streaming.py
@@ -10,6 +10,50 @@ from .. import config
 from ..client import CustomClient
 
 
+async def ensure_voice_channel(
+    interaction: discord.Interaction,
+) -> wavelink.Player:
+    if not interaction.user:
+        raise discord.DiscordException("interaction.user is None")
+
+    if not isinstance(interaction.user, discord.Member):
+        raise discord.DiscordException(
+            "interaction.user is not a discord.Member object"
+        )
+
+    author_voice = interaction.user.voice
+
+    if not author_voice:
+        await interaction.response.send_message("You're not in a voice channel")
+        raise discord.DiscordException("interaction.user.voice is None")
+
+    if not interaction.guild:
+        raise discord.DiscordException("interaction.guild is None")
+
+    player: wavelink.Player = interaction.guild.voice_client
+
+    if not player and author_voice.channel:
+        player = await author_voice.channel.connect(cls=wavelink.Player)
+        return player
+
+    if author_voice.channel != player.channel:
+        await interaction.response.send_message("You're in a different channel")
+        raise discord.DiscordException(
+            "user is in a different voice channel"
+        )
+
+    return player
+
+
+async def start_playing(player: wavelink.Player) -> None:
+    if player.playing or player.queue.is_empty:
+        return
+
+    next_item = player.queue.get()
+
+    await player.play(next_item)
+
+
 def add_streaming_commands(client: CustomClient) -> None:
     @client.tree.command(
         name="play",
@@ -94,48 +138,3 @@ def add_streaming_commands(client: CustomClient) -> None:
                 await player.disconnect()
                 await client.change_presence(status=discord.Status.idle)
 
-    async def ensure_voice_channel(
-        interaction: discord.Interaction,
-    ) -> wavelink.Player:
-        if not interaction.user:
-            raise discord.DiscordException("interaction.user is None")
-
-        if not isinstance(interaction.user, discord.Member):
-            raise discord.DiscordException(
-                "interaction.user is not a discord.Member object"
-            )
-
-        author_voice = interaction.user.voice
-
-        if not author_voice:
-            await interaction.response.send_message(
-                "You're not in a voice channel"
-            )
-            raise discord.DiscordException("interaction.user.voice is None")
-
-        if not interaction.guild:
-            raise discord.DiscordException("interaction.guild is None")
-
-        player: wavelink.Player = interaction.guild.voice_client
-
-        if not player and author_voice.channel:
-            player = await author_voice.channel.connect(cls=wavelink.Player)
-            return player
-
-        if author_voice.channel != player.channel:
-            await interaction.response.send_message(
-                "You're in a different channel"
-            )
-            raise discord.DiscordException(
-                "user is in a different voice channel"
-            )
-
-        return player
-
-    async def start_playing(player: wavelink.Player) -> None:
-        if player.playing or player.queue.is_empty:
-            return
-
-        next_item = player.queue.get()
-
-        await player.play(next_item)

--- a/discord_music_bot/helpers.py
+++ b/discord_music_bot/helpers.py
@@ -5,7 +5,7 @@ import wavelink
 
 
 def format_timedelta(delta: timedelta) -> str:
-    seconds = delta.seconds
+    seconds = int(delta.total_seconds())
     hours, remainder = divmod(seconds, 3600)
     minutes, seconds = divmod(remainder, 60)
 

--- a/discord_music_bot/player_service.py
+++ b/discord_music_bot/player_service.py
@@ -1,0 +1,165 @@
+import re
+from datetime import timedelta
+
+import discord
+import wavelink
+from wavelink import QueueMode, AutoPlayMode
+from wavelink.types.filters import Equalizer
+
+from .helpers import format_timedelta
+from .client import CustomClient
+
+
+async def toggle_pause(player: wavelink.Player) -> str:
+    if not player.playing:
+        return "Not playing"
+
+    await player.pause(not player.paused)
+    return "Paused" if player.paused else "Resumed"
+
+
+async def disconnect_player(player: wavelink.Player, client: CustomClient) -> str:
+    await player.disconnect()
+    await client.change_presence(status=discord.Status.idle)
+    return "Ok"
+
+
+async def set_player_volume(player: wavelink.Player, volume: int) -> str:
+    await player.set_volume(volume)
+    return f"Volume set to {volume}%"
+
+
+def parse_timestamp(position: str) -> timedelta | None:
+    matches = re.match(r"^(?:(?:(\d+):)?(\d+):)?(\d+)$", position)
+    if not matches:
+        return None
+
+    hours, minutes, seconds = (int(m) if m else 0 for m in matches.groups())
+    return timedelta(hours=hours, minutes=minutes, seconds=seconds)
+
+
+async def seek_player(player: wavelink.Player, position: timedelta) -> str:
+    if not player.current:
+        return "Not playing anything right now"
+
+    duration = timedelta(seconds=player.current.length)
+    if duration < position:
+        return (
+            f"Track's total length is {format_timedelta(duration)}, "
+            "that is too far"
+        )
+
+    await player.seek(position.seconds * 1000)
+    return f"Seeking to {format_timedelta(position)}"
+
+
+def parse_equalizer(settings: str) -> list[Equalizer]:
+    bands: list[Equalizer] = []
+    for param in settings.strip().split(" "):
+        if not param:
+            continue
+
+        band, gain = param.split(":")
+        bands.append(Equalizer(band=int(band), gain=float(gain)))
+    return bands
+
+
+async def apply_equalizer_settings(
+    player: wavelink.Player, bands: list[Equalizer]
+) -> str:
+    filters: wavelink.Filters = player.filters
+    filters.equalizer.set(bands=bands)
+
+    try:
+        await player.set_filters(filters, seek=True)
+    except ValueError:
+        return "Invalid value"
+
+    return "Equalizer added"
+
+
+async def set_playback_speed(
+    player: wavelink.Player, speed: float, pitch: float = 1.0
+) -> str:
+    filters: wavelink.Filters = player.filters
+    filters.timescale.set(speed=speed, pitch=pitch)
+
+    await player.set_filters(filters, seek=True)
+    return "New speed applied"
+
+
+async def reset_player_filters(player: wavelink.Player) -> str:
+    filters: wavelink.Filters = player.filters
+    filters.reset()
+
+    await player.set_filters(filters, seek=True)
+    return "Filters reset"
+
+
+def now_playing_embed(player: wavelink.Player) -> discord.Embed:
+    track = player.current
+    embed = discord.Embed(title=track.title, colour=discord.Colour.random())
+
+    if track.author:
+        embed.add_field(name="Author", value=track.author)
+
+    position = timedelta(seconds=player.position // 1000)
+    embed.add_field(name="Position", value=format_timedelta(position))
+
+    duration = timedelta(seconds=track.length // 1000)
+    embed.add_field(name="Duration", value=format_timedelta(duration))
+
+    if track.uri:
+        embed.add_field(name="Link", value=track.uri)
+
+    if track.artwork:
+        embed.set_image(url=track.artwork)
+
+    if track.album.name:
+        embed.add_field(name="Album", value=track.album.name)
+
+    return embed
+
+
+def queue_embed(tracks: list[wavelink.Playable], title: str) -> discord.Embed:
+    embed = discord.Embed(title=title, colour=discord.Colour.random())
+
+    for i, track in enumerate(tracks, start=1):
+        embed.add_field(
+            name=f"`{track.title} - {track.author}`", value=str(i)
+        )
+
+    return embed
+
+
+async def clear_queue(player: wavelink.Player) -> str:
+    player.queue.clear()
+    return "Queue cleared"
+
+
+async def skip_current(player: wavelink.Player) -> str:
+    skipped_item = await player.skip()
+    if not skipped_item:
+        return "Nothing to skip"
+
+    return (
+        f"Skipping **`{skipped_item.title} - {skipped_item.author}`**"
+    )
+
+
+def toggle_loop(player: wavelink.Player) -> str:
+    is_looped = player.queue.mode == QueueMode.normal
+    player.queue.mode = QueueMode.loop if is_looped else QueueMode.normal
+
+    return f"Current track is {'' if is_looped else 'un'}looped"
+
+
+def toggle_autoplay(player: wavelink.Player) -> str:
+    player.autoplay = (
+        AutoPlayMode.enabled
+        if player.autoplay == AutoPlayMode.disabled
+        else AutoPlayMode.disabled
+    )
+
+    state = "" if player.autoplay != AutoPlayMode.disabled else "not "
+    return f"Autoplay is {state}enabled"


### PR DESCRIPTION
## Summary
- add `player_service` module with helpers for audio control and queue management
- refactor audio and queue commands to call the new service functions
- commands now return messages from service layer for easier testing

## Testing
- `poetry run pre-commit run -a` *(fails: Command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_683fef755538832e995db0ec8282dd81